### PR TITLE
Fix favicon sizes in manifest and convert instruction file to Markdown

### DIFF
--- a/icons/web/README.md
+++ b/icons/web/README.md
@@ -8,7 +8,7 @@ Add this to your app's manifest.json:
     ...
     {
       "icons": [
-        { "src": "/favicon.ico", "type": "image/x-icon", "sizes": "16x16 32x32" },
+       { "src": "/favicon.ico", "type": "image/x-icon", "sizes": "any" },
         { "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
         { "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" },
         { "src": "/icon-192-maskable.png", "type": "image/png", "sizes": "192x192", "purpose": "maskable" },


### PR DESCRIPTION
Updated favicon entry in manifest.json by removing incorrect 'sizes' field.
 Renamed the instruction file from .txt to .md for better readability and GitHub formatting