### PR TITLE
Added Theme Toggle Icon for System, Dark and Light modes

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/rkbapps/canvas/theme/themeMode.kt
+++ b/composeApp/src/androidMain/kotlin/com/rkbapps/canvas/theme/themeMode.kt
@@ -1,0 +1,5 @@
+package com.rkbapps.canvas.theme
+
+enum class ThemeMode {
+    LIGHT, DARK, SYSTEM
+}

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/App.kt
@@ -2,21 +2,39 @@ package com.rkbapps.canvas
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.rkbapps.canvas.navigation.MainNavGraph
 import com.rkbapps.canvas.theme.AppTheme
 import org.koin.compose.KoinContext
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+
 
 
 @Composable
-internal fun App(navController: NavHostController = rememberNavController()) = AppTheme(
-    darkTheme = isSystemInDarkTheme()
-) {
-    KoinContext{
-        MainNavGraph(navController = navController)
+internal fun App(navController: NavHostController = rememberNavController()) {
+    var themeMode by rememberSaveable { mutableStateOf("System" as String) }
+
+    val darkTheme = when (themeMode) {
+        "Light" -> false
+        "Dark" -> true
+        else -> isSystemInDarkTheme()
+    }
+
+    AppTheme(darkTheme = darkTheme) {
+        KoinContext {
+            MainNavGraph(navController = navController, themeMode = themeMode, onThemeChange = { themeMode = it })
+        }
     }
 }
+
+
+
+
+
 
 
 

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/navigation/MainNavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/navigation/MainNavGraph.kt
@@ -1,5 +1,4 @@
 package com.rkbapps.canvas.navigation
-
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -8,13 +7,22 @@ import com.rkbapps.canvas.ui.screens.drawing.DrawingScreen
 import com.rkbapps.canvas.ui.screens.home.HomeScreen
 
 @Composable
-fun MainNavGraph(navController: NavHostController){
-    NavHost(navController = navController, startDestination = Home){
+fun MainNavGraph(
+    navController: NavHostController,
+    themeMode: String,
+    onThemeChange: (String) -> Unit
+) {
+    NavHost(navController = navController, startDestination = Home) {
         composable<Home> {
-            HomeScreen(navController = navController)
+            HomeScreen(
+                navController = navController,
+                themeMode = themeMode,
+                onThemeChange = onThemeChange
+            )
         }
-        composable <Draw> {
+        composable<Draw> {
             DrawingScreen(navController = navController)
         }
     }
 }
+

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/home/HomeScreen.kt
@@ -2,70 +2,50 @@ package com.rkbapps.canvas.ui.screens.home
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Brush
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastForEach
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.rkbapps.canvas.model.DrawingState
 import com.rkbapps.canvas.model.SavedDesign
 import com.rkbapps.canvas.navigation.Draw
-import com.rkbapps.canvas.ui.composables.CircularIndicator
-import com.rkbapps.canvas.ui.composables.FacebookLogo
-import com.rkbapps.canvas.ui.composables.GooglePhotosIcon
-import com.rkbapps.canvas.ui.composables.InstagramLogo
-import com.rkbapps.canvas.ui.composables.MessengerIcon
 import com.rkbapps.canvas.ui.composables.drawPath
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(navController: NavHostController, viewModel: HomeViewModel = koinViewModel()) {
-
+fun HomeScreen(navController: NavHostController,themeMode:String,onThemeChange: (String) -> Unit, viewModel: HomeViewModel = koinViewModel()) {
     val allDesign by viewModel.allDesign.collectAsStateWithLifecycle()
-    val currentDeletableProject = rememberSaveable { mutableStateOf<SavedDesign?>(null) }
+    val currentDeletableProject = remember { mutableStateOf<SavedDesign?>(null) }
+    val expanded = remember { mutableStateOf(false) }
+    val themeOptions = listOf("Light", "Dark", "System")
+    val selectedTheme = remember { mutableStateOf("System") }
+    val nextTheme = when (themeMode) {
+        "System" -> "Dark"
+        "Dark" -> "Light"
+        "Light" -> "System"
+        else -> "System"
+    }
 
-
-
+    val icon = when (themeMode) {
+        "System" -> Icons.Default.SettingsBrightness // or any meaningful "system" icon
+        "Dark" -> Icons.Default.DarkMode
+        "Light" -> Icons.Default.LightMode
+        else -> Icons.Default.SettingsBrightness
+    }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -79,6 +59,16 @@ fun HomeScreen(navController: NavHostController, viewModel: HomeViewModel = koin
                         }
                     ) {
                         Icon(imageVector = Icons.Default.Refresh, contentDescription = "refresh")
+                    }
+                    IconButton(
+                        onClick = {
+                            onThemeChange(nextTheme)
+                        }
+                    ) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = "Toggle Theme"
+                        )
                     }
                 }
             )
@@ -99,7 +89,9 @@ fun HomeScreen(navController: NavHostController, viewModel: HomeViewModel = koin
         }
     ) { innerPadding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(innerPadding)
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
@@ -139,29 +131,33 @@ fun HomeScreen(navController: NavHostController, viewModel: HomeViewModel = koin
     }
 }
 
-
-
-
-
 @Composable
 fun DesignListItem(design: SavedDesign, onDelete: () -> Unit = {}, onClick: () -> Unit = {}) {
     Card(modifier = Modifier.padding(8.dp), onClick = onClick) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(8.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
         ) {
             Box(
                 modifier = Modifier
-                    .height(200.dp).fillMaxWidth()
+                    .height(200.dp)
+                    .fillMaxWidth()
                     .clip(shape = RoundedCornerShape(16.dp))
                     .align(Alignment.CenterHorizontally)
             ) {
                 DrawingShow(
                     state = design.state,
-                    modifier = Modifier.height(200.dp).fillMaxWidth().clipToBounds()
+                    modifier = Modifier
+                        .height(200.dp)
+                        .fillMaxWidth()
+                        .clipToBounds()
                 )
             }
             Row(
-                modifier = Modifier.fillMaxWidth().padding(start = 4.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
@@ -183,7 +179,6 @@ fun DesignListItem(design: SavedDesign, onDelete: () -> Unit = {}, onClick: () -
     }
 }
 
-
 @Composable
 fun DrawingShow(
     state: DrawingState,
@@ -192,7 +187,7 @@ fun DrawingShow(
     Canvas(
         modifier = modifier.background(state.backgroundColor)
     ) {
-        state.paths.fastForEach {
+        state.paths.forEach {
             drawPath(
                 it.path,
                 it.color,
@@ -215,9 +210,8 @@ fun DrawingShow(
     }
 }
 
-
 @Composable
-fun DeleteConfirmationDialog(projectName:String,onCancel:()-> Unit,onDone: () -> Unit){
+fun DeleteConfirmationDialog(projectName: String, onCancel: () -> Unit, onDone: () -> Unit) {
     AlertDialog(
         onDismissRequest = {
             onCancel()
@@ -239,6 +233,5 @@ fun DeleteConfirmationDialog(projectName:String,onCancel:()-> Unit,onDone: () ->
             }
         }
     )
-
-
 }
+


### PR DESCRIPTION
Added Icon implementation of Changing Theme logic.
- Theme now cycles between: System → Dark → Light → System.
- Used appropriate icons for each mode.
- Default is set to System theme.
- Code tested and verified locally.

Closes  #7

Screenshots showing the implementation:
<img width="1919" height="1016" alt="Screenshot 2025-07-28 211409" src="https://github.com/user-attachments/assets/a4c812e5-423f-482a-886e-0724586313bc" />
<img width="1919" height="1015" alt="Screenshot 2025-07-28 211418" src="https://github.com/user-attachments/assets/afe685b6-f412-4496-b796-08547217a548" />
<img width="1919" height="1016" alt="Screenshot 2025-07-28 231137" src="https://github.com/user-attachments/assets/6c7570c3-d5ed-4432-95a3-5fab7b1e6456" />
<img width="1919" height="1079" alt="Screenshot 2025-07-28 231406" src="https://github.com/user-attachments/assets/9df5a590-8cf6-47fc-93ec-fb2ce2902985" />

