### PR TITLE
[FR]update readme file by adding project structure (#21)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,10 +59,10 @@ Canvas/
 │     ├── macos/
 │     └── web/          
 ├── iosApp/ 
-│     ├── iosApp.xcodeproj
+│     ├── iosApp.xcodeproj/
 │     │     ├── project.xcworkspace/
 │     │     └── project.pbxproj
-│     └── iosApp 
+│     └── iosApp/ 
 │            ├── Assets.xcassets/
 │            ├── Preview Content/Preview Assets.xcassets/
 │            ├── Info.plist

--- a/README.MD
+++ b/README.MD
@@ -30,6 +30,60 @@ Unleash your inner artist with **Paint & Draw**, the ultimate lightweight and us
 - **Multiplatform Settings** – Local database for storing user drawings 
 - **Material Design** – UI/UX guidelines and components
 
+# 📁Project Structure
+
+```bash
+Canvas/            
+├── composeApp/                    
+│        ├── desktopAppIcons/
+│        │     ├── LinuxIcon.png
+│        │     ├── MacosIcon.icns
+│        │     └── WindowsIcon.ico
+│        ├── src/
+│        │     ├── androidMain/
+│        │     ├── commonMain/
+│        │     ├── commonTest/kotlin/com/rkbapps/canvas/
+│        │     ├── iosMain/kotlin/
+│        │     ├── jvmMain/kotlin/
+│        │     ├── nativeMain/kotlin/com/rkbapps/canvas/
+│        │     └── wasmJsMain/    
+│        └── build.gradle.kts                    
+├── gradle/
+│       ├── wrapper/
+│       │     ├── gradle-wrapper.jar
+│       │     └── gradle-wrapper.properties
+│       └── libs.versions.toml          
+├── icons/
+│     ├── android/
+│     ├── ios/
+│     ├── macos/
+│     └── web/          
+├── iosApp/ 
+│     ├── iosApp.xcodeproj
+│     │     ├── project.xcworkspace/
+│     │     └── project.pbxproj
+│     └── iosApp 
+│            ├── Assets.xcassets/
+│            ├── Preview Content/Preview Assets.xcassets/
+│            ├── Info.plist
+│            └── iosApp.swift                              
+├── .gitignore                      
+├── CODE_OF_CONDUCT.md              
+├── LICENSE                
+├── README.MD                   
+├── CONTRIBUTING.md                          
+├── LICENSE    
+├── build.gradle.kts             
+├── README.md                  
+├── build.gradle.kts               
+├── gradle.properties                             
+├── gradlew
+├── gradlew.bat               
+└── settings.gradle.kts               
+          
+
+```
+
 
 # Supported Platforms
 


### PR DESCRIPTION
Issue Title: update readme file by adding project structure

fix #21 

This PR adds a "📁 Project Structure" section to the README.md file to help users and contributors better understand the organization of files and directories in the repository.

Rationale for this change
🔘 Offer a visual representation of the repo layout to aid new contributors in navigating the project faster.

🔘 Reduce onboarding time for developers by making it clear where specific functionality or files are located, which helps prevent confusion when working with the codebase.

🔘 Help contributors understand the purpose of the different files and directories at a glance, making the project more accessible for those unfamiliar with the structure.

While this may have been addressed elsewhere, having a concise project structure section directly in the README helps centralize the information and ensures that it's easily discoverable without requiring the reader to dig through multiple issues or documentation.