### PR TITLE
Made DrawingScreen mobile friendly

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -83,6 +83,8 @@ kotlin {
 
             implementation(libs.multiplatform.settings)
             implementation(libs.multiplatform.settings.coroutines)
+            //To detect screen type for larger displays
+            implementation(libs.material3.window.size.class1)
         }
 
         commonTest.dependencies {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -83,8 +83,6 @@ kotlin {
 
             implementation(libs.multiplatform.settings)
             implementation(libs.multiplatform.settings.coroutines)
-            //To detect screen type for larger displays
-            implementation(libs.material3.window.size.class1)
         }
 
         commonTest.dependencies {

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/composables/DrawingCanvas.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/composables/DrawingCanvas.kt
@@ -196,7 +196,7 @@ internal fun DrawScope.drawShape(
     }
     
     val shapePath = Path()
-    
+
     when (shapeType) {
         ShapeType.LINE -> {
             // Draw a line
@@ -224,7 +224,7 @@ internal fun DrawScope.drawShape(
             val size = maxOf(kotlin.math.abs(end.x - start.x), kotlin.math.abs(end.y - start.y))
             val endX = if (end.x >= start.x) start.x + size else start.x - size
             val endY = if (end.y >= start.y) start.y + size else start.y - size
-            
+
             shapePath.apply {
                 moveTo(start.x, start.y)
                 lineTo(endX, start.y)
@@ -237,8 +237,8 @@ internal fun DrawScope.drawShape(
         ShapeType.CIRCLE -> {
             // Draw a circle
             val radius = kotlin.math.sqrt(
-                (end.x - start.x) * (end.x - start.x) + 
-                (end.y - start.y) * (end.y - start.y)
+                (end.x - start.x) * (end.x - start.x) +
+                        (end.y - start.y) * (end.y - start.y)
             )
             drawCircle(color, radius, start, style = style)
         }
@@ -267,7 +267,7 @@ internal fun DrawScope.drawShape(
             // Draw right arrow
             val arrowLength = end.x - start.x
             val arrowHeight = kotlin.math.abs(end.y - start.y) / 3
-            
+
             // Draw the line
             drawLine(
                 color = color,
@@ -276,7 +276,7 @@ internal fun DrawScope.drawShape(
                 strokeWidth = thickness,
                 cap = StrokeCap.Round
             )
-            
+
             // Draw the arrowhead
             shapePath.apply {
                 moveTo(end.x, start.y)
@@ -290,7 +290,7 @@ internal fun DrawScope.drawShape(
             // Draw left arrow
             val arrowLength = start.x - end.x
             val arrowHeight = kotlin.math.abs(end.y - start.y) / 3
-            
+
             // Draw the line
             drawLine(
                 color = color,
@@ -299,7 +299,7 @@ internal fun DrawScope.drawShape(
                 strokeWidth = thickness,
                 cap = StrokeCap.Round
             )
-            
+
             // Draw the arrowhead
             shapePath.apply {
                 moveTo(end.x, start.y)
@@ -313,7 +313,7 @@ internal fun DrawScope.drawShape(
             // Draw up arrow
             val arrowLength = start.y - end.y
             val arrowWidth = kotlin.math.abs(end.x - start.x) / 3
-            
+
             // Draw the line
             drawLine(
                 color = color,
@@ -322,7 +322,7 @@ internal fun DrawScope.drawShape(
                 strokeWidth = thickness,
                 cap = StrokeCap.Round
             )
-            
+
             // Draw the arrowhead
             shapePath.apply {
                 moveTo(start.x, end.y)
@@ -336,7 +336,7 @@ internal fun DrawScope.drawShape(
             // Draw down arrow
             val arrowLength = end.y - start.y
             val arrowWidth = kotlin.math.abs(end.x - start.x) / 3
-            
+
             // Draw the line
             drawLine(
                 color = color,
@@ -345,7 +345,7 @@ internal fun DrawScope.drawShape(
                 strokeWidth = thickness,
                 cap = StrokeCap.Round
             )
-            
+
             // Draw the arrowhead
             shapePath.apply {
                 moveTo(start.x, end.y)
@@ -358,21 +358,21 @@ internal fun DrawScope.drawShape(
         ShapeType.STAR -> {
             // Draw a star (5-pointed)
             val radius = kotlin.math.sqrt(
-                (end.x - start.x) * (end.x - start.x) + 
-                (end.y - start.y) * (end.y - start.y)
+                (end.x - start.x) * (end.x - start.x) +
+                        (end.y - start.y) * (end.y - start.y)
             )
             val innerRadius = radius * 0.4f
-            
+
             shapePath.apply {
                 val centerX = start.x
                 val centerY = start.y
-                
+
                 for (i in 0 until 10) {
                     val angle = kotlin.math.PI / 2 + i * kotlin.math.PI / 5
                     val r = if (i % 2 == 0) radius else innerRadius
                     val x = centerX + (r * kotlin.math.cos(angle)).toFloat()
                     val y = centerY - (r * kotlin.math.sin(angle)).toFloat()
-                    
+
                     if (i == 0) {
                         moveTo(x, y)
                     } else {
@@ -386,19 +386,19 @@ internal fun DrawScope.drawShape(
         ShapeType.PENTAGON -> {
             // Draw a pentagon
             val radius = kotlin.math.sqrt(
-                (end.x - start.x) * (end.x - start.x) + 
-                (end.y - start.y) * (end.y - start.y)
+                (end.x - start.x) * (end.x - start.x) +
+                        (end.y - start.y) * (end.y - start.y)
             )
-            
+
             shapePath.apply {
                 val centerX = start.x
                 val centerY = start.y
-                
+
                 for (i in 0 until 5) {
                     val angle = kotlin.math.PI / 2 + i * 2 * kotlin.math.PI / 5
                     val x = centerX + (radius * kotlin.math.cos(angle)).toFloat()
                     val y = centerY - (radius * kotlin.math.sin(angle)).toFloat()
-                    
+
                     if (i == 0) {
                         moveTo(x, y)
                     } else {
@@ -412,19 +412,19 @@ internal fun DrawScope.drawShape(
         ShapeType.HEXAGON -> {
             // Draw a hexagon
             val radius = kotlin.math.sqrt(
-                (end.x - start.x) * (end.x - start.x) + 
-                (end.y - start.y) * (end.y - start.y)
+                (end.x - start.x) * (end.x - start.x) +
+                        (end.y - start.y) * (end.y - start.y)
             )
-            
+
             shapePath.apply {
                 val centerX = start.x
                 val centerY = start.y
-                
+
                 for (i in 0 until 6) {
                     val angle = i * 2 * kotlin.math.PI / 6
                     val x = centerX + (radius * kotlin.math.cos(angle)).toFloat()
                     val y = centerY + (radius * kotlin.math.sin(angle)).toFloat()
-                    
+
                     if (i == 0) {
                         moveTo(x, y)
                     } else {

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/DrawingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/DrawingScreen.kt
@@ -155,7 +155,8 @@ fun DrawingScreen(navController: NavHostController, viewModel: DrawingViewModel 
                 .fillMaxSize()
                 .padding(it)
                 .padding(vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (uiState.isEditDrawingNameDialogVisible) {
                 EditDrawingNameDialog(
@@ -197,7 +198,9 @@ fun DrawingScreen(navController: NavHostController, viewModel: DrawingViewModel 
             }
 
             LazyRow(
-                modifier = Modifier.fillMaxWidth().draggable(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .draggable(
                     orientation = Orientation.Horizontal,
                     state = rememberDraggableState { delta ->
                         coroutineScope.launch {

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ColorItemList.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ColorItemList.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -41,12 +43,16 @@ import com.github.skydoves.colorpicker.compose.ColorEnvelope
 import com.github.skydoves.colorpicker.compose.ColorPickerController
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 import com.rkbapps.canvas.util.Constants
+import com.rkbapps.canvas.util.getWindowSize
 
 @Composable
 fun ColorItemList(
     selectedColor:Color,
     onColorItemClick:(Color)->Unit
 ){
+    val windowSize = getWindowSize()
+    val widthSize = windowSize.widthSizeClass
+    val heightSize = windowSize.heightSizeClass
     var expanded by remember { mutableStateOf(false) }
     val colorPickerController = rememberColorPickerController()
     remember{ mutableStateOf(false) }
@@ -58,37 +64,65 @@ fun ColorItemList(
             onDone = onColorItemClick
         )
     }
-    Box(
-        modifier = Modifier
-            .size(50.dp)
-            .background(
-                color = MaterialTheme.colorScheme.primaryContainer,
-                shape = RoundedCornerShape(10.dp))
-    ){
-        Box(
-            modifier = Modifier
-                .padding(10.dp)
-                .size(35.dp)
-                .clip(CircleShape)
-                .background(
-                    color =selectedColor,
-                )
-                .clickable {
-                    expanded = true
+    when{
+        ( widthSize==WindowWidthSizeClass.Compact || heightSize==WindowHeightSizeClass.Compact) -> {
+            Box(
+                modifier = Modifier
+                    .size(50.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        shape = RoundedCornerShape(10.dp))
+            ){
+                Box(
+                    modifier = Modifier
+                        .padding(10.dp)
+                        .size(35.dp)
+                        .clip(CircleShape)
+                        .background(
+                            color =selectedColor,
+                        )
+                        .clickable {
+                            expanded = true
+                        }
+                ){}
+                DropdownMenu(
+                    expanded= expanded,
+                    onDismissRequest = {expanded = false},
+                    offset = DpOffset(x = 0.dp, y = (0).dp),
+                    modifier = Modifier.padding(10.dp)
+                ){
+                    FlowRow(modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
+                        .padding(15.dp),
+                        horizontalArrangement = Arrangement.spacedBy(18.dp),
+                        verticalArrangement = Arrangement.spacedBy(18.dp)
+                    ) {
+                        Constants.colors.forEach {
+                            ColorItems(
+                                color = it,
+                                isSelected = it == selectedColor,
+                                onClick = onColorItemClick
+                            )
+                        }
+                        ColorItems(
+                            color = if(colorPickerController.selectedColor.value == Color.Transparent) Color.White else colorPickerController.selectedColor.value,
+                            isSelected = colorPickerController.selectedColor.value == selectedColor,
+                            imageVector = Icons.Outlined.Palette
+                        ){
+                            isColorPickerDialogVisible.value = true
+                        }
+                    }
                 }
-        ){}
-        DropdownMenu(
-            expanded= expanded,
-            onDismissRequest = {expanded = false},
-            offset = DpOffset(x = 0.dp, y = (0).dp),
-            modifier = Modifier.padding(10.dp)
-        ){
-            FlowRow(modifier = Modifier
+            }
+        }
+        else->{
+            Row(modifier = Modifier
                 .fillMaxWidth()
                 .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
                 .padding(15.dp),
                 horizontalArrangement = Arrangement.spacedBy(18.dp),
-                verticalArrangement = Arrangement.spacedBy(18.dp)
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Constants.colors.forEach {
                     ColorItems(
@@ -107,6 +141,7 @@ fun ColorItemList(
             }
         }
     }
+
 }
 
 

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ColorItemList.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ColorItemList.kt
@@ -3,42 +3,42 @@ package com.rkbapps.canvas.ui.screens.drawing.composables
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.github.skydoves.colorpicker.compose.AlphaSlider
-import com.github.skydoves.colorpicker.compose.BrightnessSlider
 import com.github.skydoves.colorpicker.compose.ColorEnvelope
 import com.github.skydoves.colorpicker.compose.ColorPickerController
-import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 import com.rkbapps.canvas.util.Constants
 
@@ -47,9 +47,10 @@ fun ColorItemList(
     selectedColor:Color,
     onColorItemClick:(Color)->Unit
 ){
+    var expanded by remember { mutableStateOf(false) }
     val colorPickerController = rememberColorPickerController()
+    remember{ mutableStateOf(false) }
     val isColorPickerDialogVisible = remember { mutableStateOf(false) }
-
     if (isColorPickerDialogVisible.value){
         ColorPickerDialog(
             isColorPickerVisible = isColorPickerDialogVisible,
@@ -57,26 +58,53 @@ fun ColorItemList(
             onDone = onColorItemClick
         )
     }
-
-    Row(modifier = Modifier
-        .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
-        .padding(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        Constants.colors.forEach {
-            ColorItems(
-                color = it,
-                isSelected = it == selectedColor,
-                onClick = onColorItemClick
-            )
-        }
-        ColorItems(
-            color = if(colorPickerController.selectedColor.value == Color.Transparent) Color.White else colorPickerController.selectedColor.value,
-            isSelected = colorPickerController.selectedColor.value == selectedColor,
-            imageVector = Icons.Outlined.Palette
+    Box(
+        modifier = Modifier
+            .size(50.dp)
+            .background(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                shape = RoundedCornerShape(10.dp))
+    ){
+        Box(
+            modifier = Modifier
+                .padding(10.dp)
+                .size(35.dp)
+                .clip(CircleShape)
+                .background(
+                    color =selectedColor,
+                )
+                .clickable {
+                    expanded = true
+                }
+        ){}
+        DropdownMenu(
+            expanded= expanded,
+            onDismissRequest = {expanded = false},
+            offset = DpOffset(x = 0.dp, y = (0).dp),
+            modifier = Modifier.padding(10.dp)
         ){
-            isColorPickerDialogVisible.value = true
+            FlowRow(modifier = Modifier
+                .fillMaxWidth()
+                .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
+                .padding(15.dp),
+                horizontalArrangement = Arrangement.spacedBy(18.dp),
+                verticalArrangement = Arrangement.spacedBy(18.dp)
+            ) {
+                Constants.colors.forEach {
+                    ColorItems(
+                        color = it,
+                        isSelected = it == selectedColor,
+                        onClick = onColorItemClick
+                    )
+                }
+                ColorItems(
+                    color = if(colorPickerController.selectedColor.value == Color.Transparent) Color.White else colorPickerController.selectedColor.value,
+                    isSelected = colorPickerController.selectedColor.value == selectedColor,
+                    imageVector = Icons.Outlined.Palette
+                ){
+                    isColorPickerDialogVisible.value = true
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/PaintingStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/PaintingStyle.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowColumn
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -23,6 +24,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.rkbapps.canvas.util.getWindowSize
 
 enum class PaintingStyleType{
     STROKE,
@@ -72,34 +76,65 @@ fun PaintingStyle(
     selected:PaintingStyleType = PaintingStyleType.STROKE,
     onSelected:(PaintingStyleType)->Unit = {}
 ){
+    val windowSizeClass = getWindowSize()
+    val widthSize = windowSizeClass.widthSizeClass
+    val heightSize = windowSizeClass.heightSizeClass
     val current = paintingStyles.find { it.type == selected } ?: paintingStyles.first()
     var expanded by remember{ mutableStateOf(false) }
-    Box(
-        modifier = Modifier
-            .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
-            .padding(vertical = 4.dp, horizontal = 8.dp)
-    ){
-        PaintingStyleItem(
-            isSelected = true,
-            icon = {
-                Icon(imageVector = current.icon, contentDescription = current.title, modifier = Modifier.size(20.dp))
-            },
-            title = {
-                Text(current.title, style = MaterialTheme.typography.labelSmall)
-            },
-            onClick = { expanded = true }
-        )
-        DropdownMenu(
-            expanded,
-            onDismissRequest = {expanded = false},
-            offset = DpOffset(x = (-10).dp, y = 0.dp)
-        ){
-            FlowColumn(
+    when{
+        (widthSize == WindowWidthSizeClass.Compact || heightSize == WindowHeightSizeClass.Compact) ->{
+            Box(
+                modifier = Modifier
+                    .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
+                    .padding(vertical = 4.dp, horizontal = 8.dp)
+            ){
+                PaintingStyleItem(
+                    isSelected = true,
+                    icon = {
+                        Icon(imageVector = current.icon, contentDescription = current.title, modifier = Modifier.size(20.dp))
+                    },
+                    title = {
+                        Text(current.title, style = MaterialTheme.typography.labelSmall)
+                    },
+                    onClick = { expanded = true }
+                )
+                DropdownMenu(
+                    expanded,
+                    onDismissRequest = {expanded = false},
+                    offset = DpOffset(x = (-10).dp, y = 0.dp)
+                ){
+                    FlowColumn(
+                        modifier = Modifier
+                            .padding(10.dp)
+                            .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
+                            .padding(vertical = 4.dp, horizontal = 8.dp),
+                        verticalArrangement  = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        paintingStyles.forEach {
+                            PaintingStyleItem(
+                                isSelected = selected==it.type,
+                                icon = {
+                                    Icon(imageVector = it.icon, contentDescription = it.title, modifier = Modifier.size(20.dp))
+                                },
+                                title = {
+                                    Text(it.title, style = MaterialTheme.typography.labelSmall)
+                                }
+                            ) {
+                                onSelected(it.type)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else -> {
+            Row(
                 modifier = Modifier
                     .padding(10.dp)
                     .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
                     .padding(vertical = 4.dp, horizontal = 8.dp),
-                verticalArrangement  = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 paintingStyles.forEach {
@@ -118,6 +153,7 @@ fun PaintingStyle(
             }
         }
     }
+
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/PaintingStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/PaintingStyle.kt
@@ -7,9 +7,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.FlowColumn
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,15 +19,21 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.HorizontalRule
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.RadioButtonChecked
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 
 enum class PaintingStyleType{
@@ -67,24 +72,48 @@ fun PaintingStyle(
     selected:PaintingStyleType = PaintingStyleType.STROKE,
     onSelected:(PaintingStyleType)->Unit = {}
 ){
-    Row(
+    val current = paintingStyles.find { it.type == selected } ?: paintingStyles.first()
+    var expanded by remember{ mutableStateOf(false) }
+    Box(
         modifier = Modifier
             .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
-            .padding(vertical = 4.dp, horizontal = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        paintingStyles.forEach {
-            PaintingStyleItem(
-                isSelected = selected==it.type,
-                icon = {
-                    Icon(imageVector = it.icon, contentDescription = it.title, modifier = Modifier.size(20.dp))
-                },
-                title = {
-                    Text(it.title, style = MaterialTheme.typography.labelSmall)
-                }
+            .padding(vertical = 4.dp, horizontal = 8.dp)
+    ){
+        PaintingStyleItem(
+            isSelected = true,
+            icon = {
+                Icon(imageVector = current.icon, contentDescription = current.title, modifier = Modifier.size(20.dp))
+            },
+            title = {
+                Text(current.title, style = MaterialTheme.typography.labelSmall)
+            },
+            onClick = { expanded = true }
+        )
+        DropdownMenu(
+            expanded,
+            onDismissRequest = {expanded = false},
+            offset = DpOffset(x = (-10).dp, y = 0.dp)
+        ){
+            FlowColumn(
+                modifier = Modifier
+                    .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
+                    .padding(vertical = 4.dp, horizontal = 8.dp),
+                verticalArrangement  = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                onSelected(it.type)
+                paintingStyles.forEach {
+                    PaintingStyleItem(
+                        isSelected = selected==it.type,
+                        icon = {
+                            Icon(imageVector = it.icon, contentDescription = it.title, modifier = Modifier.size(20.dp))
+                        },
+                        title = {
+                            Text(it.title, style = MaterialTheme.typography.labelSmall)
+                        }
+                    ) {
+                        onSelected(it.type)
+                    }
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/PaintingStyle.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/PaintingStyle.kt
@@ -96,6 +96,7 @@ fun PaintingStyle(
         ){
             FlowColumn(
                 modifier = Modifier
+                    .padding(10.dp)
                     .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
                     .padding(vertical = 4.dp, horizontal = 8.dp),
                 verticalArrangement  = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ShapeSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ShapeSelector.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -19,6 +20,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +36,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.rkbapps.canvas.util.getWindowSize
 
 data class ShapeOption(
     val type: ShapeType,
@@ -46,43 +50,79 @@ fun ShapeSelector(
     shapes: List<ShapeOption>,
     onShapeSelected: (ShapeType) -> Unit
 ) {
+    val windowSize = getWindowSize()
+    val widthSize = windowSize.widthSizeClass
+    val heightSize = windowSize.heightSizeClass
     val current = shapes.find { it.type==selectedShape }?: shapes.first()
     var expanded by remember{ mutableStateOf(false) }
-    Box(
-        modifier = Modifier
-            .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
-            .padding(vertical = 4.dp, horizontal = 8.dp)
-    ) {
-        ShapeSelectorItem(
-            isSelected = true,
-            icon = {
-                Icon(
-                    imageVector = current.icon,
-                    contentDescription = current.title,
-                    modifier = Modifier.size(20.dp)
+    when{
+        (widthSize == WindowWidthSizeClass.Compact || heightSize == WindowHeightSizeClass.Compact)->{
+            Box(
+                modifier = Modifier
+                    .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
+                    .padding(vertical = 4.dp, horizontal = 8.dp)
+            ) {
+                ShapeSelectorItem(
+                    isSelected = true,
+                    icon = {
+                        Icon(
+                            imageVector = current.icon,
+                            contentDescription = current.title,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    },
+                    title = {
+                        Text(
+                            text = current.title,
+                            style = MaterialTheme.typography.labelSmall,
+                            textAlign = TextAlign.Center,
+                            fontSize = 10.sp
+                        )
+                    },
+                    onClick = {
+                        expanded = true
+                    }
                 )
-            },
-            title = {
-                Text(
-                    text = current.title,
-                    style = MaterialTheme.typography.labelSmall,
-                    textAlign = TextAlign.Center,
-                    fontSize = 10.sp
-                )
-            },
-            onClick = {
-                expanded = true
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                    offset = DpOffset(x = 0.dp,y=0.dp)
+                ){
+                    FlowRow(
+                        modifier = Modifier.padding(start = 15.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        shapes.forEach { shape ->
+                            ShapeSelectorItem(
+                                isSelected = selectedShape == shape.type,
+                                icon = {
+                                    Icon(
+                                        imageVector = shape.icon,
+                                        contentDescription = shape.title,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                },
+                                title = {
+                                    Text(
+                                        text = shape.title,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        textAlign = TextAlign.Center,
+                                        fontSize = 10.sp
+                                    )
+                                },
+                                onClick = { onShapeSelected(shape.type) }
+                            )
+                        }
+                    }
+                }
             }
-        )
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            offset = DpOffset(x = 0.dp,y=0.dp)
-        ){
-            FlowRow(
+        }
+        else ->{
+            Row(
                 modifier = Modifier.padding(start = 15.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 shapes.forEach { shape ->
                     ShapeSelectorItem(

--- a/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ShapeSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/rkbapps/canvas/ui/screens/drawing/composables/ShapeSelector.kt
@@ -7,27 +7,30 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -43,36 +46,65 @@ fun ShapeSelector(
     shapes: List<ShapeOption>,
     onShapeSelected: (ShapeType) -> Unit
 ) {
+    val current = shapes.find { it.type==selectedShape }?: shapes.first()
+    var expanded by remember{ mutableStateOf(false) }
     Box(
         modifier = Modifier
             .background(color = MaterialTheme.colorScheme.primaryContainer, shape = RoundedCornerShape(10.dp))
             .padding(vertical = 4.dp, horizontal = 8.dp)
     ) {
-        Row(
-            modifier = Modifier,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            shapes.forEach { shape ->
-                ShapeSelectorItem(
-                    isSelected = selectedShape == shape.type,
-                    icon = {
-                        Icon(
-                            imageVector = shape.icon,
-                            contentDescription = shape.title,
-                            modifier = Modifier.size(20.dp)
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = shape.title,
-                            style = MaterialTheme.typography.labelSmall,
-                            textAlign = TextAlign.Center,
-                            fontSize = 10.sp
-                        )
-                    },
-                    onClick = { onShapeSelected(shape.type) }
+        ShapeSelectorItem(
+            isSelected = true,
+            icon = {
+                Icon(
+                    imageVector = current.icon,
+                    contentDescription = current.title,
+                    modifier = Modifier.size(20.dp)
                 )
+            },
+            title = {
+                Text(
+                    text = current.title,
+                    style = MaterialTheme.typography.labelSmall,
+                    textAlign = TextAlign.Center,
+                    fontSize = 10.sp
+                )
+            },
+            onClick = {
+                expanded = true
+            }
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            offset = DpOffset(x = 0.dp,y=0.dp)
+        ){
+            FlowRow(
+                modifier = Modifier.padding(start = 15.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                shapes.forEach { shape ->
+                    ShapeSelectorItem(
+                        isSelected = selectedShape == shape.type,
+                        icon = {
+                            Icon(
+                                imageVector = shape.icon,
+                                contentDescription = shape.title,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        },
+                        title = {
+                            Text(
+                                text = shape.title,
+                                style = MaterialTheme.typography.labelSmall,
+                                textAlign = TextAlign.Center,
+                                fontSize = 10.sp
+                            )
+                        },
+                        onClick = { onShapeSelected(shape.type) }
+                    )
+                }
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 
+androidxMaterial3WindowSizeClass = "1.3.2"
 kotlin = "2.1.20"
 compose = "1.8.0-beta02"
 agp = "8.9.1"
@@ -30,6 +31,7 @@ androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycl
 androidx-navigation-compose = {module="org.jetbrains.androidx.navigation:navigation-compose",version.ref="navigation-compose"}
 coil = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+material3-window-size-class1 = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "androidxMaterial3WindowSizeClass" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatformSettings" }
 sketch-compose = {module="io.github.panpf.sketch4:sketch-compose",version.ref = "sketchCompose"}


### PR DESCRIPTION
# Pull Request

## Description

In this PR I changed the composables of drawing screen by changing the Row elements with FlowRow elements and kept them inside a dropdown menu so it will open a drop down list of the items to select from, thus reducing the space which adjusts perfectly in mobile screens.

**Closes Issue**
#10 

**Type of Issue**
UI improvement

**Testing**
I've tested the changes in android studio's emulator. I had only tested for android as for iOS i need to have a mac which I doesn't.
Since, it is an UI change so I'm pretty confident that the changes will work perfectly fine on IOS too.

**Demo of Changes**
https://github.com/user-attachments/assets/df6a1f29-fad7-4463-90ec-e747465e2880

